### PR TITLE
Remove the optional chaining operator

### DIFF
--- a/db/database.js
+++ b/db/database.js
@@ -12,7 +12,7 @@ const getUserWithEmail = function (email) {
   let resolvedUser = null;
   for (const userId in users) {
     const user = users[userId];
-    if (user?.email.toLowerCase() === email?.toLowerCase()) {
+    if (user && user.email.toLowerCase() === email.toLowerCase()) {
       resolvedUser = user;
     }
   }


### PR DESCRIPTION
The optional chaining operator (`?`) is not compatible with Node version 12 (which we ask non-M1/M2 users to install).